### PR TITLE
Lift the tensor unit

### DIFF
--- a/gap/CategoriesWithAmbientObjects.gi
+++ b/gap/CategoriesWithAmbientObjects.gi
@@ -286,6 +286,32 @@ InstallMethod( CategoryWithAmbientObject,
           end;
     fi;
     
+    ## TensorUnit with ambient object
+    preconditions := [ "TensorUnit" ];
+    
+    if ForAll( preconditions, c -> CanCompute( abelian_category, c ) ) then
+        
+        structure_record.TensorUnit :=
+          function( underlying_tensor_unit )
+            local gen, lazy;
+            
+            gen := AsGeneralizedMorphismByCospan( IdentityMorphism( underlying_tensor_unit ) );
+            
+            Assert( 4, IsMonomorphism( gen ) );
+            SetIsSplitMonomorphism( gen, true );
+            
+            lazy := CreateLazyGeneralizedEmbeddingInAmbientObject(
+                            underlying_tensor_unit,
+                            IdFunc,
+                            [ [ IdFunc, gen ] ] );
+            
+            SetEvaluatedGeneralizedEmbeddingInAmbientObject( lazy, gen );
+            
+            return [ lazy ];
+            
+          end;
+    fi;
+    
     ## DirectSum with ambient object
     preconditions := [ "DirectSum",
                        "PreCompose" ];


### PR DESCRIPTION
It has the identity morphism as its generalized embedding.
We need this to be able to construct the M2 module `1*R`
by a Cap-specific command.